### PR TITLE
Http Code and Redirect Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,19 @@ app.get('/', function (req, res) {
 });
 ```
 
+If using TypeScript, you can import the `HttpResponse` class and do `return new HttpResponse('Hello World', 200)`. Specifying a status code is optional and will default to 200 if not specified.
+
+### Redirect
+
+You can return a property `redirect`, which is a URL that will be passed into the `res.redirect`. If specifying `redirect`, you can optionally specify a status code. Redirect cannot be used with a body; if both are passed in, redirect takes precedence.
+
+If using Typescript, you can import the `HttpRedirect` class and do `return new HttpResponse('http://google.com')'. The first parameter is the URL to redirect to, and the optional second parameter is a status code.`
+
+### Status Code Only
+
+You can specify just a status code without a body.
+
+If using TypeScript, you can import the `HttpCode` class and do `return new HttpCode(404)`. Alternatively, you can use `HttpRespones`, passing in `null` as the first parameter: `return new HttpResponse(null, 404)`.
+
 ### Error Handling
 If an exception is thrown or the returned promise is rejected, the wrapper code will pass the error into `next`, which will pass it into error handling middleware (if defined).

--- a/examples/basic-examples.ts
+++ b/examples/basic-examples.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import {createApplication, HttpResponse} from '../index';
+import {createApplication, HttpResponse, HttpCode, HttpRedirect} from '../index';
 
 const app = express();
 createApplication(app);
@@ -18,6 +18,8 @@ Try out one of the sample endpoints: <br />
     <li><a href="/promise">/promise</a></li>
     <li><a href="/promise/error">/promise/error</a></li>
     <li><a href="/promise/reject">/promise/reject</a></li>
+    <li><a href="/redirect/me">/redirect-me</a></li>
+    <li><a href="/redirect/me/301">/redirect/me/301</a></li>
 </ul>
     `);
 });
@@ -48,7 +50,15 @@ app.get('/promise/reject', function (req: express.Request) {
 });
 
 app.get('/just/code', function () {
-  return Promise.resolve({code: 201});
+  return Promise.resolve(new HttpCode(201));
+});
+
+app.get('/redirect/me', function () {
+  return Promise.resolve(new HttpRedirect('http://google.com'));
+});
+
+app.get('/redirect/me/301', function () {
+  return Promise.resolve(new HttpRedirect('http://google.com', 301));
 });
 
 // Error handler

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 
 export {HttpResponse} from './lib/models/http-response';
 export {HttpCode} from './lib/models/http-code';
+export {HttpRedirect} from './lib/models/http-redirect';
 export {createApplication, modifyRouter} from './lib/express-return';

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 
 export {HttpResponse} from './lib/models/http-response';
+export {HttpCode} from './lib/models/http-code';
 export {createApplication, modifyRouter} from './lib/express-return';

--- a/lib/express-return.ts
+++ b/lib/express-return.ts
@@ -49,13 +49,24 @@ function handleResult(_res: any, res: express.Response): Promise<any> {
   }
   return _res.then((_resData: any) => {
     if (_resData) {
+
+      if (_resData.redirect) {
+        // Optional 'code' param appears at the start
+        // https://expressjs.com/en/4x/api.html#res.redirect
+        if (_resData.code) {
+          res.redirect(_resData.code, _resData.redirect);
+        } else {
+          res.redirect(_resData.redirect);
+        }
+        return;
+      }
+
       if (_resData.code) {
         res.status(_resData.code);
       }
-      // If it has a body, send it;
-      // if it doesn't have a body
-      // but does have a status code,
-      // end the request
+
+      // If it has a body, send it; if it doesn't have a body
+      // but does have a status code, end the request
       if (_resData.body) {
         res.send(_resData.body);
       } else if (_resData.code) {

--- a/lib/models/http-code.ts
+++ b/lib/models/http-code.ts
@@ -1,0 +1,7 @@
+export class HttpCode {
+  code: number;
+
+  constructor(code?: number) {
+    this.code = code;
+  }
+}

--- a/lib/models/http-redirect.ts
+++ b/lib/models/http-redirect.ts
@@ -1,0 +1,9 @@
+export class HttpRedirect {
+  redirect: string;
+  code: number;
+
+  constructor(redirect: string, code?: number) {
+    this.redirect = redirect;
+    this.code = code;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "express-mocks-http": "0.0.11",
     "mocha": "^3.5.3",
     "sinon": "^2.4.1",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "typescript": "^2.6.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test --recursive",
+    "compile": "tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
  * Create a new class that allow specifying just HTTP Code. Not new functionality, but should make code cleaner (`return new HttpCode(201)`) instead of (`return new HttpResponse(null, 201)`)

  * Created a HttpRedirect class, and added in functionality to support this